### PR TITLE
Support newer ipython versions

### DIFF
--- a/ripdb/__init__.py
+++ b/ripdb/__init__.py
@@ -25,7 +25,10 @@ except NameError:
     ipshell = InteractiveShellEmbed()
     def_colors = ipshell.colors
 else:
-    def_colors = get_ipython.im_self.colors
+    try:
+        def_colors = get_ipython.im_self.colors
+    except AttributeError:
+        def_colors = get_ipython.__self__.colors
 
 
 class Rpdb(pdb.Pdb):


### PR DESCRIPTION
Newer ipython versions have no `get_ipython.im_self` attribute.